### PR TITLE
Removed nonexistent template path

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -11,7 +11,7 @@ app.config( function ( $mdThemingProvider, $routeProvider )
 		'default': '700'
 	}).accentPalette( 'blue' );
 
-	$routeProvider.when( "/home", { Title: "Home", templateUrl: "html/home.html" } )
+	$routeProvider.when( "/home", { Title: "Home" } )
 	$routeProvider.when( "/:address/console", { Title: "Console", templateUrl: "html/console.html", Nav: true } )
 	$routeProvider.when( "/:address/playerlist", { Title: "Player List", templateUrl: "html/playerlist.html", Nav: true } )
 	$routeProvider.when( "/:address/player/:userid", { Title: "Player Info", templateUrl: "html/playerInfo.html" } )


### PR DESCRIPTION
There is no "html/home.html" template. Attempting to download file with this address causes an "$compile:tpload" error.
