### PR TITLE
Strip HTML tags from chat messages

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -20,6 +20,7 @@ function ChatController( $scope, rconService, $timeout )
 
 	$scope.OnMessage = function( msg )
 	{
+		msg.Message = stripHtml(msg.Message);
 		$scope.Output.push( msg );
 		
 		if($scope.isOnBottom()) {
@@ -76,4 +77,12 @@ function ChatController( $scope, rconService, $timeout )
 	}
 
 	rconService.InstallService( $scope, $scope.GetHistory )
+}
+
+function stripHtml(html)
+{
+	if (html == null) return "";
+	var tmp = document.createElement("div");
+	tmp.innerHTML = html;
+	return tmp.textContent || tmp.innerText || "";
 }


### PR DESCRIPTION
A lot of servers use HTML tags (especially colors), which produce hard to read chat messages, like this one:
```
SERVER : - <color=#FFE4C4>poliisi</color> <color=#DC143C>said goodbye to</color> <color=#FFE4C4>Peruna</color>
```

I've added a function that strips HTML tags from all chat messages, so they'll be more readable from now on.