### PR TITLE
Wrong SteamId

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -15,6 +15,7 @@ function ChatController( $scope, rconService, $timeout )
 	{
 		if ( msg.Type !== "Chat" ) return;
 
+		msg.Message = msg.Message.replace(/(\"UserId\"\:)\s(\d+)(,)/g, "$1\"$2\"$3");
 		$scope.OnMessage( JSON.parse( msg.Message ) );
 	});
 
@@ -66,6 +67,7 @@ function ChatController( $scope, rconService, $timeout )
 	{
 		rconService.Request( "chat.tail 512", $scope, function ( msg )
 		{
+			msg.Message = msg.Message.replace(/(\"UserId\"\:)\s(\d+)(,)/g, "$1\"$2\"$3");
 			var messages = JSON.parse( msg.Message );
 
 			messages.forEach( function ( message ) {


### PR DESCRIPTION
Linked to this issue : https://github.com/Facepunch/webrcon/issues/16

The UserId is send as an Integer and interpreted as well by the js part. But it exceed the maximum js integer, which is 9007199254740991 (16 digits), the steamId is 17 digits long. That's why the last digit was rounded.

The other way is to send the UserId as a string instead of force the js part to re-interpret it.